### PR TITLE
Revert "Fetch the correct VM even when the param is `vm` and not `id`…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ class BackupReportsXoPlugin {
       let vm
 
       try {
-        vm = this._xo.getObject(call.params.id || call.params.vm)
+        vm = this._xo.getObject(call.params.id)
       } catch (e) {}
 
       const start = moment(call.start)


### PR DESCRIPTION
… (fix #3)."